### PR TITLE
fix: poor formatting of the .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry = https://npm.pkg.github.com/ligo-dev
-//npm.pkg.github.com/:_authToken=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM docker:19.03.2
-LABEL "repository"="https://github.com/ferluisxd/create-npmrc"
-LABEL "maintainer"="Luis Vilca"
+FROM docker:19.03.2 
+# TODO: Change this to run something other than Docker in Docker
+LABEL "repository"="https://github.com/tendable/create-npmrc"
+LABEL "maintainer"="Tendable"
 
 RUN apk update \
   && apk upgrade \

--- a/README.md
+++ b/README.md
@@ -1,33 +1,30 @@
-# Create a .npmrc file for the github repository
+# Create a .npmrc file for the Github Package Registry
 
-Github workflow action to create `.npmrc` file for github to the root folder
+Github action to create `.npmrc` file for Github packages in the root folder
 
 Pass all sensitive data using secrets.
 
 ## Inputs
 
-### `org_name`
+### `org_name` (optional)
 
-Organization name (Github repository name)
+The organization name, defaults to `tendable`
 
 ### `auth_token` (optional)
 
-AuthToken that is able to download files from the repository, can also be passed as env and it's rather recommended this way
-
+Auth token that is able to download files from the repository, can also be passed as env. It seems like passing it as a variable is preferred.
 
 ## Example usage
 
 ```ylm
 uses: tendable/create-npmrc@3
 with:
-  org_name: tendable
-  env:
-    AUTH_TOKEN: ${{ secrets.github_auth_token }}
+  auth_token: ${{ secrets.github_auth_token }}
 ```
 
 ## Example output
 
 ```npmrc
-registry = https://npm.pkg.github.com/tendable
+@tendable:registry=https://npm.pkg.github.com/
 //npm.pkg.github.com/:_authToken=31352d11daasdf769942919dsafas594a5d
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ branding:
   icon: 'box'
 inputs:
   org_name:
-    description: 'Github repository name'
-    required: true
+    description: 'Github organization name'
+    required: false
   auth_token:
-    description: 'AuthToken for github'
+    description: 'Auth token for Github'
     required: false
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -l
-echo "registry = https://npm.pkg.github.com/$INPUT_ORG_NAME" > .npmrc
+if [[ -z "$INPUT_ORG_NAME" ]]; then
+    echo "@tendable:registry=https://npm.pkg.github.com/" > .npmrc
+else
+    echo "@$INPUT_ORG_NAME:registry=https://npm.pkg.github.com/" > .npmrc
+fi
 if [[ -z "$INPUT_AUTH_TOKEN" ]]; then
     echo "//npm.pkg.github.com/:_authToken=$AUTH_TOKEN" >> .npmrc
 else


### PR DESCRIPTION
**Problem**:
The existing output looks like:

```
registry = https://npm.pkg.github.com/tendable
//npm.pkg.github.com/:_authToken=REDACTED
```

It should look like:
```
@tendable:registry=https://npm.pkg.github.com/
//npm.pkg.github.com/:_authToken=***
```

**Changes**:

* Delete a `.npmrc` file that was checked in
* Update the README to provide better examples
* Make the org field optional
* Change the format output to be correct!
* Mark the container as Tendable